### PR TITLE
Fixed bug

### DIFF
--- a/python/MLN/learning/BPLL.py
+++ b/python/MLN/learning/BPLL.py
@@ -98,7 +98,7 @@ class BPLL(PLL):
             p = self.blockProbsMB[idxVar][self.evidenceIndices[idxVar]]
             if p == 0: p = 1e-10 # prevent 0 probabilities
             probs.append(p)
-        return fsum(map(log, probs))
+        return nympy.array(float(fsum(map(log, probs))))
    
     def _grad(self, wt):
         self._calculateBlockProbsMB(wt)


### PR DESCRIPTION
Bug fixed that causes the bfgs optimizer to crash when a MPMath type is returned from the _f function in BPLL.py.
